### PR TITLE
Change minimum MCB free to 0x700 (merged from the upstream)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
 0.83.1
+  - Minimum MCB free default changed to better reflect
+    a typical MS-DOS setup with minimal to no drivers.
+    This should result in a report of 600K-ish memory
+    free, which is equivalent to Windows 95 without
+    anything loaded except COMMAND.COM.
   - Various improvements to DEL and COPY commands, e.g.
     fixed the DEL /P option having no effect, and "DEL ."
     deleted all files in the current directory silently;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2710,7 +2710,7 @@ public:
          *      start segment before or after 0x800 helps to resolve these issues.
          *      It also puts DOSBox-X at parity with main DOSBox SVN behavior. */
         if (minimum_mcb_free == 0)
-            minimum_mcb_free = IS_PC98_ARCH ? 0x800 : 0x100;
+            minimum_mcb_free = IS_PC98_ARCH ? 0x800 : 0x700;
         else if (minimum_mcb_free < minimum_mcb_segment)
             minimum_mcb_free = minimum_mcb_segment;
 


### PR DESCRIPTION
# Description
This merges some changes from the upstream ([joncampbell123:master](https://github.com/joncampbell123/dosbox-x/tree/master)), which changes the minimum MCB free.

**Does this PR address some issue(s)?**
Quoted from c6c3845,

> 0x100 invites too many DOS games to crash and too many users posting "this game works in SVN but crashes in X" issues that are immediately resolved in LOADFIX

This means it fixes some DOS games.

**Are there any breaking changes?**
The minimum MCB free is changed, thus breaking applications that rely on that old amount.

**Additional information**
This PR is to simply update the AppVeyor build subsequently.